### PR TITLE
hotfix(OrdersTab): añade estado paid y corrige flujo de transiciones

### DIFF
--- a/src/api/models/order.py
+++ b/src/api/models/order.py
@@ -12,9 +12,9 @@ class Payment(enum.Enum):
 
 class Status(enum.Enum):
     pending = "pending"         #--Está en el carrito
-    processing = "processing"   #--Se está procesando el pago
     paid = "paid"               #--Pago confirmado
     confirmed = "confirmed"     #--Vendedor recibe/abre el aviso
+    processing = "processing"   #--Se está  está preparando el envío
     shipped = "shipped"         #--Vendedor confirma envió con el código de envío
     delivered = "delivered"     #--Entregado
     cancelled = "cancelled"     #--Cancelado

--- a/src/front/components/Profile/ProfileRole/SellerDashBoard/OrdersTab.jsx
+++ b/src/front/components/Profile/ProfileRole/SellerDashBoard/OrdersTab.jsx
@@ -3,6 +3,7 @@ import useGlobalReducer from "../../../../hooks/useGlobalReducer";
 
 const STATUS_STYLE = {
   pending: "bg-yellow-100 text-yellow-700",
+  paid: "bg-teal-100 text-teal-700",
   confirmed: "bg-blue-100 text-blue-700",
   processing: "bg-purple-100 text-purple-700",
   shipped: "bg-indigo-100 text-indigo-700",
@@ -12,6 +13,7 @@ const STATUS_STYLE = {
 
 const STATUS_LABEL = {
   pending: "Pendiente",
+  paid: "Pagado",
   confirmed: "Confirmado",
   processing: "Procesando",
   shipped: "Enviado",
@@ -20,12 +22,14 @@ const STATUS_LABEL = {
 };
 
 const NEXT_STATUSES = {
+  pending:[],
+  paid: ["confirmed", "cancelled"],
   confirmed: ["processing", "cancelled"],
   processing:["shipped", "cancelled"],
   shipped: ["delivered"],
   delivered: [],
   cancelled:[],
-  pending:[],
+  
 };
 
 const PAYMENT_LABEL = {
@@ -261,7 +265,7 @@ const OrdersTab = () => {
                   <span>€{Number(selected.subtotal).toFixed(2)}</span>
                 </div>
                 <div className="flex justify-between text-gray-500">
-                  <span>IVA (21%)</span>
+                  <span>IVA incluido  (21%)</span>
                   <span>€{Number(selected.tax).toFixed(2)}</span>
                 </div>
                 <div className="flex justify-between text-gray-500">


### PR DESCRIPTION
## Descripción
Qué hace este PR y por qué.
Corrige el componente OrdersTab para incluir el estado `paid` en el flujo de pedidos y ajusta las transiciones de estado según el flujo acordado.
---

## Historia de Usuario
US #

## Tareas
- Closes #

---

## Tipo de cambio
- [ ] Feature
- [ ] Bug
- [ ] UI / Estilos

---

## Cambios realizados
- 
- 
- 


---

## Checklist
- [ ] Funciona como se espera
- [ ] Cumple criterios de aceptación de la tarea
- [ ] No rompe otras partes
- [ ] Probado manualmente
- [ ] Estoy trabajando en una rama para específica para esta tarea
