### PR TITLE
feat(i18n)

### DIFF
--- a/src/front/i18n/ca.json
+++ b/src/front/i18n/ca.json
@@ -18,11 +18,13 @@
     "shipping": "Enviament gratuït en comandes superiors a 50 €. Devolucions acceptades durant 30 dies.",
     "inStock": "En estoc",
     "outOfStock": "Sense estoc",
+    "noStock": "No hi ha més estoc disponible",
     "available": "disponibles",
     "addToCart": "Afegir a la cistella",
-    "reviews": "Opinions de clients",
     "addedToCart": "Producte afegit a la teva cistella",
-    "loginRequired": "Has d'iniciar sessió per afegir productes al carret"
+    "reviews": "Opinions de clients",
+    "loginRequired": "Has d'iniciar sessió per afegir productes a la cistella",
+    "cartError": "Error en afegir a la cistella"
   },
   "navbar": {
     "loginTitle": "Benvingut de nou",
@@ -41,7 +43,7 @@
     "forgotPasswordButton": "Recupera-la aquí",
     "profile": "Perfil",
     "orders": "Comandes",
-    "favorites": "Preferits",
+    "favorites": "Favorits",
     "cart": "Cistella",
     "logout": "Tancar sessió",
     "labelCategories": "Categories",
@@ -59,7 +61,7 @@
     "forgotSuccess": "Si el correu existeix rebràs instruccions en breu",
     "missingToken": "Token no trobat. Utilitza l'enllaç del correu.",
     "goHome": "Anar a l'inici",
-    "backToLogin": "Tornar a Iniciar sessió",
+    "backToLogin": "Tornar a l'inici de sessió",
     "resetTitle": "Restableix la teva contrasenya",
     "newPasswordPlaceholder": "La teva nova contrasenya",
     "confirmPasswordPlaceholder": "Confirma la teva nova contrasenya",
@@ -71,14 +73,14 @@
       "new": "Nou",
       "used": "Usat",
       "refurbished": "Recondicionat",
-      "broken": "Espatllat"
+      "broken": "Per a peces"
     }
   },
   "search": {
     "filters": "Filtres",
     "sort": "Ordenar",
     "applyPrice": "Aplicar preu",
-    "clearAll": "Netejar tots els filtres",
+    "clearAll": "Esborrar tots els filtres",
     "noResults": "Sense resultats",
     "noResultsHint": "Prova a canviar els filtres o el terme de cerca.",
     "clearFilters": "Treure tots els filtres",
@@ -117,7 +119,7 @@
     "stepConfirm": "Confirmació",
     "name": "Nom",
     "lastName": "Cognom",
-    "email": "Correu",
+    "email": "Correu electrònic",
     "password": "Contrasenya",
     "confirmPassword": "Confirmar contrasenya",
     "storeName": "Nom de la botiga",
@@ -146,15 +148,15 @@
     "errorRequiredFields": "Omple tots els camps obligatoris",
     "becomeSeller": "Vendre a Playback",
     "myStore": "La meva botiga",
-    "adminPanel": "Panell d'administració",
+    "adminPanel": "Tauler d'administració",
     "adminPanelDesc": "Gestiona els venedors i aprova o rebutja sol·licituds.",
-    "goToAdminPanel": "Anar al panell d'admin",
+    "goToAdminPanel": "Anar al tauler d'admin",
     "goToDashboard": "Anar a la meva botiga",
     "registerSubtitle": "Uneix-te a la nostra comunitat de venedors i arriba a milers de compradors.",
     "pendingTitle": "Sol·licitud en revisió",
     "pendingDesc": "Estem revisant la teva sol·licitud. T'avisarem quan estigui aprovada.",
     "verifiedTitle": "La teva botiga està activa!",
-    "verifiedDesc": "Ja pots gestionar els teus productes i comandes des del teu panell de venedor.",
+    "verifiedDesc": "Ja pots gestionar els teus productes i comandes des del teu tauler de venedor.",
     "rejectedTitle": "Sol·licitud rebutjada",
     "rejectedDesc": "La teva sol·licitud no ha estat aprovada. Contacta amb suport per a més informació.",
     "editTitle": "Corregir sol·licitud",
@@ -166,7 +168,7 @@
     "cancelApplication": "Cancel·lar sol·licitud",
     "stripe": {
       "title": "Connecta el teu compte de pagaments",
-      "desc": "Per rebre pagaments de les teves vendes necessites connectar el teu compte amb Stripe. El procés triga menys de 5 minuts.",
+      "desc": "Per rebre pagaments de les teves vendes has de connectar el teu compte amb Stripe. El procés triga menys de 5 minuts.",
       "opening": "Obrint...",
       "cta": "Registrar-me a Stripe →"
     }
@@ -181,6 +183,8 @@
     "subtotal": "Subtotal",
     "tax": "IVA inclòs (21%)",
     "shipping": "Enviament",
+    "freeShipping": "Gratis",
+    "discount": "Descompte",
     "total": "Total",
     "goToPayment": "Anar al pagament",
     "continueToPayment": "Continuar al pagament",
@@ -189,6 +193,16 @@
     "newAddress": "Nova adreça",
     "save": "Desar",
     "saving": "Desant...",
+    "selectAddress": "Selecciona adreça d'enviament i facturació",
+    "shippingAddress": "Adreça d'enviament",
+    "billingAddress": "Adreça de facturació",
+    "sameAsBilling": "Usar la mateixa adreça per a facturació",
+    "enterPayment": "Introdueix el teu mètode de pagament",
+    "couponQuestion": "Tens un codi de descompte?",
+    "couponPlaceholder": "Introdueix el teu codi",
+    "couponApply": "Aplicar",
+    "couponApplied": "Cupó aplicat",
+    "couponInvalid": "Codi invàlid o caducat",
     "addr": {
       "fullName": "Nom complet",
       "address": "Adreça",
@@ -197,22 +211,81 @@
       "province": "Província (opcional)",
       "postalCode": "Codi postal",
       "country": "País"
-    },
-    "selectAddress": "Selecciona adreça d'enviament i facturació",
-    "shippingAddress": "Adreça d'enviament",
-    "billingAddress": "Adreça de facturació",
-    "sameAsBilling": "Utilitzar la mateixa adreça per a facturació",
-    "enterPayment": "Introdueix el teu mètode de pagament"
+    }
   },
   "cart": {
     "title": "Cistella",
-    "empty": "La teva cistella està buida",
+    "empty": "La teva cistella és buida",
     "remove": "Eliminar"
+  },
+  "orders": {
+    "title": "Historial de comandes",
+    "empty": "Encara no tens comandes",
+    "order": "Comanda",
+    "date": "Data",
+    "status": "Estat",
+    "units": "Unitats",
+    "shippingCost": "Despeses d'enviament",
+    "shippingAddress": "Adreça d'enviament",
+    "billingAddress": "Adreça de facturació"
+  },
+  "favorites": {
+    "title": "Els teus favorits",
+    "empty": "Encara no tens favorits"
+  },
+  "profile": {
+    "myAccount": "El meu compte",
+    "tabs": {
+      "dashboard": "Tauler de control",
+      "info": "Informació",
+      "addresses": "Adreces",
+      "security": "Seguretat"
+    },
+    "manage": "Gestionar",
+    "userPanel": "Tauler d'Usuari",
+    "info": {
+      "currentInfo": "Informació Actual",
+      "editInfo": "Editar Informació",
+      "nameRequired": "El nom és obligatori",
+      "lastNameRequired": "El cognom és obligatori",
+      "imageFormat": "Format no permès. Utilitza JPG, PNG o WEBP.",
+      "imageSize": "La imatge no pot superar els 2MB.",
+      "imageUploadError": "Error en pujar la imatge",
+      "imageUpdated": "Imatge actualitzada correctament",
+      "connectionError": "Error de connexió",
+      "uploading": "Pujant...",
+      "changeImage": "Canviar Imatge",
+      "saving": "Desant...",
+      "saveChanges": "Desar Canvis",
+      "confirmChanges": "Estàs segur de desar els canvis?",
+      "confirm": "Confirmar",
+      "close": "Tancar",
+      "profileUpdated": "Perfil actualitzat correctament"
+    },
+    "addresses": {
+      "title": "Les meves Adreces",
+      "main": "Adreça Principal",
+      "setMain": "Usar com a principal",
+      "edit": "Editar",
+      "delete": "Eliminar",
+      "empty": "No tens adreces desades.",
+      "addNew": "Afegir Nova Adreça",
+      "save": "Desar Adreça",
+      "saved": "Adreça desada correctament",
+      "municipality": "Municipi"
+    },
+    "security": {
+      "title": "Canviar Contrasenya",
+      "currentPassword": "Contrasenya actual",
+      "update": "Actualitzar contrasenya",
+      "updated": "Contrasenya actualitzada correctament",
+      "error": "Error en actualitzar la contrasenya"
+    }
   },
   "admin": {
     "rejectTitle": "Rebutjar sol·licitud",
     "rejectDesc1": "Indica el motiu del rebuig de",
-    "rejectDesc2": ". El venedor podrà llegir-ho i corregir la seva sol·licitud.",
+    "rejectDesc2": ". El venedor podrà llegir-lo i corregir la seva sol·licitud.",
     "rejectPlaceholder": "Ex: El NIF introduït no és vàlid. Si us plau revisa'l i torna a enviar la sol·licitud.",
     "confirmReject": "Confirmar rebuig",
     "verify": "Verificar",
@@ -231,11 +304,11 @@
     "detail": {
       "userData": "Dades de l'usuari",
       "name": "Nom",
-      "email": "Correu",
+      "email": "Correu electrònic",
       "role": "Rol",
       "account": "Compte",
-      "active": "Actiu",
-      "inactive": "Inactiu",
+      "active": "Activa",
+      "inactive": "Inactiva",
       "storeData": "Dades de la botiga",
       "store": "Botiga",
       "nifCif": "NIF / CIF",
@@ -246,7 +319,7 @@
       "city": "Ciutat",
       "zip": "CP",
       "country": "País",
-      "accountId": "ID de compte",
+      "accountId": "ID del compte",
       "accountCreated": "Compte creat",
       "yes": "Sí",
       "no": "No",
@@ -258,7 +331,7 @@
       "inOrders": "En comandes",
       "request": "Sol·licitud"
     },
-    "panelTitle": "Panell d'administració",
+    "panelTitle": "Tauler d'administració",
     "panelDesc": "Gestiona venedors, usuaris i incidències de la plataforma.",
     "tabs": {
       "stats": "Estadístiques",
@@ -320,7 +393,7 @@
         "confirmed": "Confirmat",
         "processing": "En preparació",
         "shipped": "Enviat",
-        "delivered": "Lliurat",
+        "delivered": "Entregat",
         "cancelled": "Cancel·lat"
       },
       "payment": {
@@ -340,6 +413,9 @@
       "confirmDelete": "Eliminar aquest producte?",
       "edit": "Editar",
       "delete": "Eliminar",
+      "deleted": "Producte eliminat",
+      "stockError": "Error en actualitzar l'estoc",
+      "saved": "Producte desat",
       "table": {
         "product": "Producte",
         "price": "Preu",
@@ -351,6 +427,8 @@
         "newTitle": "Nou producte",
         "changeImage": "Canviar imatge",
         "uploadImage": "Pujar imatge",
+        "noImage": "Sense imatge",
+        "imageRequired": "La imatge és obligatòria.",
         "formatError": "Utilitza JPG, PNG o WEBP.",
         "sizeError": "Màxim 2MB.",
         "name": "Nom",
@@ -392,71 +470,11 @@
       "zip": "Codi postal",
       "country": "País",
       "description": "Descripció breu",
+      "originAddress": "Adreça d'origen",
       "saving": "Desant…",
       "save": "Desar canvis",
-      "success": "✅ Desat correctament.",
-      "error": "❌ Error en desar."
-    }
-  },
-  "orders": {
-    "title": "Historial de comandes",
-    "empty": "Encara no tens comandes",
-    "order": "Comanda",
-    "date": "Data",
-    "status": "Estat",
-    "units": "Unitats",
-    "shippingCost": "Despeses d'enviament",
-    "shippingAddress": "Adreça d'enviament",
-    "billingAddress": "Adreça de facturació"
-  },
-  "favorites": {
-    "title": "Els teus preferits",
-    "empty": "Encara no tens preferits"
-  },
-  "profile": {
-    "myAccount": "El meu Compte",
-    "tabs": {
-      "dashboard": "Tauler de control",
-      "info": "Informació",
-      "addresses": "Adreces",
-      "security": "Seguretat"
-    },
-    "manage": "Gestionar",
-    "userPanel": "Tauler d'Usuari",
-    "info": {
-      "currentInfo": "Informació Actual",
-      "editInfo": "Editar Informació",
-      "nameRequired": "El nom és obligatori",
-      "lastNameRequired": "El cognom és obligatori",
-      "imageFormat": "Format no permès. Utilitza JPG, PNG o WEBP.",
-      "imageSize": "La imatge no pot superar els 2MB.",
-      "imageUploadError": "Error en pujar la imatge",
-      "imageUpdated": "Imatge actualitzada correctament",
-      "connectionError": "Error de connexió",
-      "uploading": "Pujant...",
-      "changeImage": "Canviar Imatge",
-      "saving": "Desant...",
-      "saveChanges": "Desar Canvis",
-      "confirmChanges": "Estàs segur que vols desar els canvis?",
-      "confirm": "Confirmar",
-      "close": "Tancar",
-      "profileUpdated": "Perfil actualitzat correctament"
-    },
-    "addresses": {
-      "title": "Les meves Adreces",
-      "main": "Adreça Principal",
-      "setMain": "Usar com a principal",
-      "delete": "Eliminar",
-      "addNew": "Afegir Nova Adreça",
-      "save": "Desar Adreça",
-      "saved": "Adreça desada correctament",
-      "municipality": "Municipi"
-    },
-    "security": {
-      "title": "Canviar Contrasenya",
-      "currentPassword": "Contrasenya actual",
-      "update": "Actualitzar contrasenya",
-      "updated": "Contrasenya actualitzada"
+      "success": "Desat correctament.",
+      "error": "Error en desar."
     }
   },
   "review": {

--- a/src/front/i18n/en.json
+++ b/src/front/i18n/en.json
@@ -4,7 +4,7 @@
     "topSales": "Top Sales",
     "featuredCategories": "Featured Categories",
     "heroBannerSpan1": "Special offer!",
-    "heroBannerSpan2": "See Offers",
+    "heroBannerSpan2": "View Offers",
     "featuredProducts": "Featured Products",
     "viewSubcategory": "View subcategory"
   },
@@ -18,17 +18,19 @@
     "shipping": "Free shipping on orders over €50. Returns accepted within 30 days.",
     "inStock": "In stock",
     "outOfStock": "Out of stock",
+    "noStock": "No more stock available",
     "available": "available",
     "addToCart": "Add to cart",
-    "reviews": "Customer reviews",
     "addedToCart": "Product added to your cart",
-    "loginRequired": "You must be logged in to add products to the cart"
+    "reviews": "Customer reviews",
+    "loginRequired": "You must be logged in to add products to your cart",
+    "cartError": "Error adding to cart"
   },
   "navbar": {
     "loginTitle": "Welcome back",
     "signupTitle": "Create your account",
-    "nameLabel": "Name",
-    "namePlaceholder": "Your name",
+    "nameLabel": "First name",
+    "namePlaceholder": "Your first name",
     "lastNameLabel": "Last name",
     "lastNamePlaceholder": "Your last name",
     "passwordPlaceholder": "Your password",
@@ -58,20 +60,20 @@
     "forgotButton": "Send instructions",
     "forgotSuccess": "If the email exists you will receive instructions shortly",
     "missingToken": "Token not found. Use the link from the email.",
-    "goHome": "Go home",
+    "goHome": "Go to home",
     "backToLogin": "Back to login",
     "resetTitle": "Reset your password",
     "newPasswordPlaceholder": "Your new password",
     "confirmPasswordPlaceholder": "Confirm your new password",
     "resetButton": "Reset password",
-    "resetSuccess": "Your password has been reset successfully. You can now log in with your new password."
+    "resetSuccess": "Your password has been successfully reset. You can now log in with your new password."
   },
   "enums": {
     "productCondition": {
       "new": "New",
       "used": "Used",
       "refurbished": "Refurbished",
-      "broken": "Broken"
+      "broken": "For parts"
     }
   },
   "search": {
@@ -81,7 +83,7 @@
     "clearAll": "Clear all filters",
     "noResults": "No results",
     "noResultsHint": "Try changing the filters or search term.",
-    "clearFilters": "Clear all filters",
+    "clearFilters": "Remove all filters",
     "searching": "Searching...",
     "productCount_one": "{{count}} product",
     "productCount_other": "{{count}} products",
@@ -93,7 +95,7 @@
     "conditionSection": "Condition",
     "onSale": "On sale",
     "inStockOnly": "In stock only",
-    "lowStock": "Low stock",
+    "lowStock": "Few units left",
     "lowStockBadge": "Last",
     "seeAll": "See all results for \"{{query}}\" →",
     "sort_relevance": "Relevance",
@@ -102,12 +104,12 @@
     "sort_rating": "Best rated",
     "sort_newest": "Newest",
     "sort_discount": "Biggest discount",
-    "sort_stock_asc": "Low stock first",
+    "sort_stock_asc": "Few units first",
     "filterChip_min_price": "From {{value}}€",
     "filterChip_max_price": "Up to {{value}}€",
     "filterChip_in_stock": "In stock",
     "filterChip_on_sale": "On sale",
-    "filterChip_low_stock": "Low stock"
+    "filterChip_low_stock": "Few units"
   },
   "seller": {
     "registerTitle": "Become a seller",
@@ -115,13 +117,13 @@
     "stepStore": "Store",
     "stepShipping": "Shipping & Banking",
     "stepConfirm": "Confirmation",
-    "name": "Name",
+    "name": "First name",
     "lastName": "Last name",
     "email": "Email",
     "password": "Password",
     "confirmPassword": "Confirm password",
     "storeName": "Store name",
-    "nifCif": "VAT number",
+    "nifCif": "Tax ID",
     "storeDescription": "Store description",
     "storeDescriptionPlaceholder": "Tell us what you sell...",
     "phone": "Contact phone",
@@ -143,7 +145,7 @@
     "errorPasswordMatch": "Passwords do not match",
     "errorPasswordLength": "Password must be at least 8 characters",
     "errorRequired": "This field is required",
-    "errorRequiredFields": "Fill in all required fields",
+    "errorRequiredFields": "Please fill in all required fields",
     "becomeSeller": "Sell on Playback",
     "myStore": "My store",
     "adminPanel": "Admin panel",
@@ -153,16 +155,16 @@
     "registerSubtitle": "Join our seller community and reach thousands of buyers.",
     "pendingTitle": "Application under review",
     "pendingDesc": "We are reviewing your application. We will notify you once it is approved.",
-    "verifiedTitle": "Your store is active!",
-    "verifiedDesc": "You can now manage your products and orders from your seller panel.",
+    "verifiedTitle": "Your store is live!",
+    "verifiedDesc": "You can now manage your products and orders from your seller dashboard.",
     "rejectedTitle": "Application rejected",
-    "rejectedDesc": "Your application has not been approved. Contact support for more information.",
+    "rejectedDesc": "Your application was not approved. Contact support for more information.",
     "editTitle": "Correct application",
     "editSubtitle": "Correct the indicated data and resubmit your application.",
     "resubmitNotice": "Your corrected application will return to pending status for review.",
     "resubmit": "Resubmit application",
     "rejectionReason": "Rejection reason",
-    "cancelApplicationDesc": "If you do not wish to correct the application, you can cancel it and start again.",
+    "cancelApplicationDesc": "If you do not wish to correct the application, you can cancel it and start over.",
     "cancelApplication": "Cancel application",
     "stripe": {
       "title": "Connect your payment account",
@@ -181,6 +183,8 @@
     "subtotal": "Subtotal",
     "tax": "VAT included (21%)",
     "shipping": "Shipping",
+    "freeShipping": "Free",
+    "discount": "Discount",
     "total": "Total",
     "goToPayment": "Go to payment",
     "continueToPayment": "Continue to payment",
@@ -189,6 +193,16 @@
     "newAddress": "New address",
     "save": "Save",
     "saving": "Saving...",
+    "selectAddress": "Please select a shipping and billing address",
+    "shippingAddress": "Shipping address",
+    "billingAddress": "Billing address",
+    "sameAsBilling": "Use the same address for billing",
+    "enterPayment": "Enter your payment method",
+    "couponQuestion": "Do you have a discount code?",
+    "couponPlaceholder": "Enter your code",
+    "couponApply": "Apply",
+    "couponApplied": "Coupon applied",
+    "couponInvalid": "Invalid or expired code",
     "addr": {
       "fullName": "Full name",
       "address": "Address",
@@ -197,23 +211,82 @@
       "province": "Province (optional)",
       "postalCode": "Postcode",
       "country": "Country"
-    },
-    "selectAddress": "Select shipping and billing address",
-    "shippingAddress": "Shipping address",
-    "billingAddress": "Billing address",
-    "sameAsBilling": "Use the same address for billing",
-    "enterPayment": "Enter your payment method"
+    }
   },
   "cart": {
     "title": "Cart",
     "empty": "Your cart is empty",
     "remove": "Remove"
   },
+  "orders": {
+    "title": "Order history",
+    "empty": "You have no orders yet",
+    "order": "Order",
+    "date": "Date",
+    "status": "Status",
+    "units": "Units",
+    "shippingCost": "Shipping cost",
+    "shippingAddress": "Shipping address",
+    "billingAddress": "Billing address"
+  },
+  "favorites": {
+    "title": "Your favourites",
+    "empty": "You have no favourites yet"
+  },
+  "profile": {
+    "myAccount": "My Account",
+    "tabs": {
+      "dashboard": "Dashboard",
+      "info": "Information",
+      "addresses": "Addresses",
+      "security": "Security"
+    },
+    "manage": "Manage",
+    "userPanel": "User Panel",
+    "info": {
+      "currentInfo": "Current Information",
+      "editInfo": "Edit Information",
+      "nameRequired": "First name is required",
+      "lastNameRequired": "Last name is required",
+      "imageFormat": "Format not allowed. Use JPG, PNG or WEBP.",
+      "imageSize": "Image cannot exceed 2MB.",
+      "imageUploadError": "Error uploading image",
+      "imageUpdated": "Image updated successfully",
+      "connectionError": "Connection error",
+      "uploading": "Uploading...",
+      "changeImage": "Change Image",
+      "saving": "Saving...",
+      "saveChanges": "Save Changes",
+      "confirmChanges": "Are you sure you want to save the changes?",
+      "confirm": "Confirm",
+      "close": "Close",
+      "profileUpdated": "Profile updated successfully"
+    },
+    "addresses": {
+      "title": "My Addresses",
+      "main": "Main Address",
+      "setMain": "Set as main",
+      "edit": "Edit",
+      "delete": "Delete",
+      "empty": "You have no saved addresses.",
+      "addNew": "Add New Address",
+      "save": "Save Address",
+      "saved": "Address saved successfully",
+      "municipality": "Municipality"
+    },
+    "security": {
+      "title": "Change Password",
+      "currentPassword": "Current password",
+      "update": "Update password",
+      "updated": "Password updated successfully",
+      "error": "Error updating password"
+    }
+  },
   "admin": {
     "rejectTitle": "Reject application",
     "rejectDesc1": "Indicate the reason for rejecting",
     "rejectDesc2": ". The seller will be able to read it and correct their application.",
-    "rejectPlaceholder": "E.g.: The VAT number entered is not valid. Please check it and resubmit.",
+    "rejectPlaceholder": "E.g.: The Tax ID entered is not valid. Please review it and resubmit your application.",
     "confirmReject": "Confirm rejection",
     "verify": "Verify",
     "reject": "Reject",
@@ -238,7 +311,7 @@
       "inactive": "Inactive",
       "storeData": "Store data",
       "store": "Store",
-      "nifCif": "VAT number",
+      "nifCif": "Tax ID",
       "phone": "Phone",
       "description": "Description",
       "shippingAddress": "Shipping address",
@@ -283,16 +356,16 @@
       "loading": "Loading earnings…",
       "totalRevenue": "Total revenue",
       "completedOrders": "Completed orders",
-      "avgTicket": "Average ticket",
+      "avgTicket": "Average order value",
       "revenueByMonth": "Revenue by month",
-      "lastMovements": "Latest movements",
+      "lastMovements": "Recent transactions",
       "order": "Order",
-      "noMovements": "No movements yet."
+      "noMovements": "No transactions yet."
     },
     "orders": {
       "loading": "Loading orders…",
       "found": "orders found",
-      "noOrders": "No orders yet.",
+      "noOrders": "You have no orders yet.",
       "noAddress": "Not available",
       "table": {
         "order": "Order",
@@ -318,7 +391,7 @@
         "pending": "Pending",
         "paid": "Paid",
         "confirmed": "Confirmed",
-        "processing": "In preparation",
+        "processing": "Processing",
         "shipped": "Shipped",
         "delivered": "Delivered",
         "cancelled": "Cancelled"
@@ -335,11 +408,14 @@
       "loading": "Loading products…",
       "count": "products",
       "newProduct": "+ New product",
-      "noProducts": "No products yet.",
+      "noProducts": "You have no products yet.",
       "noStock": "Out of stock",
       "confirmDelete": "Delete this product?",
       "edit": "Edit",
       "delete": "Delete",
+      "deleted": "Product deleted",
+      "stockError": "Error updating stock",
+      "saved": "Product saved",
       "table": {
         "product": "Product",
         "price": "Price",
@@ -351,6 +427,8 @@
         "newTitle": "New product",
         "changeImage": "Change image",
         "uploadImage": "Upload image",
+        "noImage": "No image",
+        "imageRequired": "Image is required.",
         "formatError": "Use JPG, PNG or WEBP.",
         "sizeError": "Maximum 2MB.",
         "name": "Name",
@@ -392,71 +470,11 @@
       "zip": "Postcode",
       "country": "Country",
       "description": "Brief description",
+      "originAddress": "Origin address",
       "saving": "Saving…",
       "save": "Save changes",
-      "success": "✅ Saved successfully.",
-      "error": "❌ Error saving."
-    }
-  },
-  "orders": {
-    "title": "Order history",
-    "empty": "You have no orders yet",
-    "order": "Order",
-    "date": "Date",
-    "status": "Status",
-    "units": "Units",
-    "shippingCost": "Shipping costs",
-    "shippingAddress": "Shipping address",
-    "billingAddress": "Billing address"
-  },
-  "favorites": {
-    "title": "Your favourites",
-    "empty": "You have no favourites yet"
-  },
-  "profile": {
-    "myAccount": "My Account",
-    "tabs": {
-      "dashboard": "Dashboard",
-      "info": "Information",
-      "addresses": "Addresses",
-      "security": "Security"
-    },
-    "manage": "Manage",
-    "userPanel": "User Panel",
-    "info": {
-      "currentInfo": "Current Information",
-      "editInfo": "Edit Information",
-      "nameRequired": "Name is required",
-      "lastNameRequired": "Last name is required",
-      "imageFormat": "Format not allowed. Use JPG, PNG or WEBP.",
-      "imageSize": "Image cannot exceed 2MB.",
-      "imageUploadError": "Error uploading image",
-      "imageUpdated": "Image updated successfully",
-      "connectionError": "Connection error",
-      "uploading": "Uploading...",
-      "changeImage": "Change Image",
-      "saving": "Saving...",
-      "saveChanges": "Save Changes",
-      "confirmChanges": "Are you sure you want to save changes?",
-      "confirm": "Confirm",
-      "close": "Close",
-      "profileUpdated": "Profile updated successfully"
-    },
-    "addresses": {
-      "title": "My Addresses",
-      "main": "Main Address",
-      "setMain": "Set as main",
-      "delete": "Delete",
-      "addNew": "Add New Address",
-      "save": "Save Address",
-      "saved": "Address saved successfully",
-      "municipality": "Municipality"
-    },
-    "security": {
-      "title": "Change Password",
-      "currentPassword": "Current password",
-      "update": "Update password",
-      "updated": "Password updated"
+      "success": "Saved successfully.",
+      "error": "Error saving."
     }
   },
   "review": {

--- a/src/front/i18n/es.json
+++ b/src/front/i18n/es.json
@@ -18,11 +18,13 @@
     "shipping": "Envío gratuito en pedidos superiores a 50 €. Devoluciones aceptadas durante 30 días.",
     "inStock": "En stock",
     "outOfStock": "Sin stock",
+    "noStock": "No hay más stock disponible",
     "available": "disponibles",
     "addToCart": "Añadir a la cesta",
-    "reviews": "Opiniones de clientes",
     "addedToCart": "Producto añadido a tu cesta",
-    "loginRequired": "Debes iniciar sesión para añadir productos al carrito"
+    "reviews": "Opiniones de clientes",
+    "loginRequired": "Debes iniciar sesión para añadir productos al carrito",
+    "cartError": "Error al añadir al carrito"
   },
   "navbar": {
     "loginTitle": "Bienvenido de nuevo",
@@ -181,6 +183,8 @@
     "subtotal": "Subtotal",
     "tax": "IVA incluido (21%)",
     "shipping": "Envío",
+    "freeShipping": "Gratis",
+    "discount": "Descuento",
     "total": "Total",
     "goToPayment": "Ir al pago",
     "continueToPayment": "Continuar al pago",
@@ -189,6 +193,16 @@
     "newAddress": "Nueva dirección",
     "save": "Guardar",
     "saving": "Guardando...",
+    "selectAddress": "Selecciona dirección de envío y facturación",
+    "shippingAddress": "Dirección de envío",
+    "billingAddress": "Dirección de facturación",
+    "sameAsBilling": "Usar la misma dirección para facturación",
+    "enterPayment": "Introduce tu método de pago",
+    "couponQuestion": "¿Tienes un código de descuento?",
+    "couponPlaceholder": "Introduce tu código",
+    "couponApply": "Aplicar",
+    "couponApplied": "Cupón aplicado",
+    "couponInvalid": "Código inválido o expirado",
     "addr": {
       "fullName": "Nombre completo",
       "address": "Dirección",
@@ -197,17 +211,76 @@
       "province": "Provincia (opcional)",
       "postalCode": "Código postal",
       "country": "País"
-    },
-    "selectAddress": "Selecciona dirección de envío y facturación",
-    "shippingAddress": "Dirección de envío",
-    "billingAddress": "Dirección de facturación",
-    "sameAsBilling": "Usar la misma dirección para facturación",
-    "enterPayment": "Introduce tu método de pago"
+    }
   },
   "cart": {
     "title": "Carrito",
     "empty": "Tu carrito está vacío",
     "remove": "Eliminar"
+  },
+  "orders": {
+    "title": "Historial de pedidos",
+    "empty": "No tienes pedidos todavía",
+    "order": "Pedido",
+    "date": "Fecha",
+    "status": "Estado",
+    "units": "Unidades",
+    "shippingCost": "Gastos de envío",
+    "shippingAddress": "Dirección de envío",
+    "billingAddress": "Dirección de facturación"
+  },
+  "favorites": {
+    "title": "Tus favoritos",
+    "empty": "No tienes favoritos todavía"
+  },
+  "profile": {
+    "myAccount": "Mi Cuenta",
+    "tabs": {
+      "dashboard": "Panel de control",
+      "info": "Información",
+      "addresses": "Direcciones",
+      "security": "Seguridad"
+    },
+    "manage": "Gestionar",
+    "userPanel": "Panel de Usuario",
+    "info": {
+      "currentInfo": "Información Actual",
+      "editInfo": "Editar Información",
+      "nameRequired": "El nombre es obligatorio",
+      "lastNameRequired": "El apellido es obligatorio",
+      "imageFormat": "Formato no permitido. Usa JPG, PNG o WEBP.",
+      "imageSize": "La imagen no puede superar los 2MB.",
+      "imageUploadError": "Error al subir imagen",
+      "imageUpdated": "Imagen actualizada correctamente",
+      "connectionError": "Error de conexión",
+      "uploading": "Subiendo...",
+      "changeImage": "Cambiar Imagen",
+      "saving": "Guardando...",
+      "saveChanges": "Guardar Cambios",
+      "confirmChanges": "¿Estás seguro de guardar los cambios?",
+      "confirm": "Confirmar",
+      "close": "Cerrar",
+      "profileUpdated": "Perfil actualizado correctamente"
+    },
+    "addresses": {
+      "title": "Mis Direcciones",
+      "main": "Dirección Principal",
+      "setMain": "Usar como principal",
+      "edit": "Editar",
+      "delete": "Eliminar",
+      "empty": "No tienes direcciones guardadas.",
+      "addNew": "Añadir Nueva Dirección",
+      "save": "Guardar Dirección",
+      "saved": "Dirección guardada correctamente",
+      "municipality": "Municipio"
+    },
+    "security": {
+      "title": "Cambiar Contraseña",
+      "currentPassword": "Contraseña actual",
+      "update": "Actualizar contraseña",
+      "updated": "Contraseña actualizada correctamente",
+      "error": "Error al actualizar la contraseña"
+    }
   },
   "admin": {
     "rejectTitle": "Rechazar solicitud",
@@ -340,6 +413,9 @@
       "confirmDelete": "¿Eliminar este producto?",
       "edit": "Editar",
       "delete": "Eliminar",
+      "deleted": "Producto eliminado",
+      "stockError": "Error al actualizar stock",
+      "saved": "Producto guardado",
       "table": {
         "product": "Producto",
         "price": "Precio",
@@ -351,6 +427,8 @@
         "newTitle": "Nuevo producto",
         "changeImage": "Cambiar imagen",
         "uploadImage": "Subir imagen",
+        "noImage": "Sin imagen",
+        "imageRequired": "La imagen es obligatoria.",
         "formatError": "Usa JPG, PNG o WEBP.",
         "sizeError": "Máximo 2MB.",
         "name": "Nombre",
@@ -392,71 +470,11 @@
       "zip": "Código postal",
       "country": "País",
       "description": "Descripción breve",
+      "originAddress": "Dirección de origen",
       "saving": "Guardando…",
       "save": "Guardar cambios",
-      "success": "✅ Guardado correctamente.",
-      "error": "❌ Error al guardar."
-    }
-  },
-  "orders": {
-    "title": "Historial de pedidos",
-    "empty": "No tienes pedidos todavía",
-    "order": "Pedido",
-    "date": "Fecha",
-    "status": "Estado",
-    "units": "Unidades",
-    "shippingCost": "Gastos de envío",
-    "shippingAddress": "Dirección de envío",
-    "billingAddress": "Dirección de facturación"
-  },
-  "favorites": {
-    "title": "Tus favoritos",
-    "empty": "No tienes favoritos todavía"
-  },
-  "profile": {
-    "myAccount": "Mi Cuenta",
-    "tabs": {
-      "dashboard": "Panel de control",
-      "info": "Información",
-      "addresses": "Direcciones",
-      "security": "Seguridad"
-    },
-    "manage": "Gestionar",
-    "userPanel": "Panel de Usuario",
-    "info": {
-      "currentInfo": "Información Actual",
-      "editInfo": "Editar Información",
-      "nameRequired": "El nombre es obligatorio",
-      "lastNameRequired": "El apellido es obligatorio",
-      "imageFormat": "Formato no permitido. Usa JPG, PNG o WEBP.",
-      "imageSize": "La imagen no puede superar los 2MB.",
-      "imageUploadError": "Error al subir imagen",
-      "imageUpdated": "Imagen actualizada correctamente",
-      "connectionError": "Error de conexión",
-      "uploading": "Subiendo...",
-      "changeImage": "Cambiar Imagen",
-      "saving": "Guardando...",
-      "saveChanges": "Guardar Cambios",
-      "confirmChanges": "¿Estás seguro de guardar los cambios?",
-      "confirm": "Confirmar",
-      "close": "Cerrar",
-      "profileUpdated": "Perfil actualizado correctamente"
-    },
-    "addresses": {
-      "title": "Mis Direcciones",
-      "main": "Dirección Principal",
-      "setMain": "Usar como principal",
-      "delete": "Eliminar",
-      "addNew": "Añadir Nueva Dirección",
-      "save": "Guardar Dirección",
-      "saved": "Dirección guardada correctamente",
-      "municipality": "Municipio"
-    },
-    "security": {
-      "title": "Cambiar Contraseña",
-      "currentPassword": "Contraseña actual",
-      "update": "Actualizar contraseña",
-      "updated": "Contraseña actualizada"
+      "success": "Guardado correctamente.",
+      "error": "Error al guardar."
     }
   },
   "review": {

--- a/src/front/i18n/gl.json
+++ b/src/front/i18n/gl.json
@@ -1,4 +1,3 @@
-
 {
   "home": {
     "loading": "Cargando...",
@@ -19,11 +18,13 @@
     "shipping": "Envío gratuíto en pedidos superiores a 50 €. Devolucións aceptadas durante 30 días.",
     "inStock": "En stock",
     "outOfStock": "Sen stock",
+    "noStock": "Non hai máis stock dispoñible",
     "available": "dispoñibles",
     "addToCart": "Engadir á cesta",
-    "reviews": "Opinións de clientes",
     "addedToCart": "Produto engadido á túa cesta",
-    "loginRequired": "Debes iniciar sesión para engadir produtos ao carriño"
+    "reviews": "Opinións de clientes",
+    "loginRequired": "Debes iniciar sesión para engadir produtos á cesta",
+    "cartError": "Erro ao engadir á cesta"
   },
   "navbar": {
     "loginTitle": "Benvido de novo",
@@ -60,7 +61,7 @@
     "forgotSuccess": "Se o correo existe recibirás instrucións en breve",
     "missingToken": "Token non atopado. Usa a ligazón do correo.",
     "goHome": "Ir ao inicio",
-    "backToLogin": "Volver ao Inicio de sesión",
+    "backToLogin": "Volver ao inicio de sesión",
     "resetTitle": "Restablece o teu contrasinal",
     "newPasswordPlaceholder": "O teu novo contrasinal",
     "confirmPasswordPlaceholder": "Confirma o teu novo contrasinal",
@@ -72,7 +73,7 @@
       "new": "Novo",
       "used": "Usado",
       "refurbished": "Reacondicionado",
-      "broken": "Estragado"
+      "broken": "Para pezas"
     }
   },
   "search": {
@@ -104,8 +105,8 @@
     "sort_newest": "Máis recentes",
     "sort_discount": "Maior desconto",
     "sort_stock_asc": "Poucas unidades primeiro",
-    "filterChip_min_price": "Desde {{value}}€",
-    "filterChip_max_price": "Ata {{value}}€",
+    "filterChip_min_price": "Dende {{value}}€",
+    "filterChip_max_price": "Até {{value}}€",
     "filterChip_in_stock": "En stock",
     "filterChip_on_sale": "En oferta",
     "filterChip_low_stock": "Poucas unidades"
@@ -118,7 +119,7 @@
     "stepConfirm": "Confirmación",
     "name": "Nome",
     "lastName": "Apelido",
-    "email": "Correo",
+    "email": "Correo electrónico",
     "password": "Contrasinal",
     "confirmPassword": "Confirmar contrasinal",
     "storeName": "Nome da tenda",
@@ -133,14 +134,14 @@
     "iban": "IBAN",
     "accountHolder": "Titular da conta",
     "reviewTitle": "Revisa a túa solicitude",
-    "pendingNotice": "A túa solicitude quedará pendente ata que un administrador a aprobe.",
+    "pendingNotice": "A túa solicitude quedará pendente até que un administrador a aprobe.",
     "submit": "Enviar solicitude",
     "submitting": "Enviando...",
     "next": "Seguinte",
     "back": "Atrás",
     "cancel": "Cancelar",
     "successTitle": "Solicitude enviada!",
-    "successMsg": "Revisaremos a túa solicitude e recibirás unha resposta en breve.",
+    "successMsg": "Revisaremos a túa solicitude e recibirás unha resposta pronto.",
     "errorPasswordMatch": "Os contrasinais non coinciden",
     "errorPasswordLength": "O contrasinal debe ter polo menos 8 caracteres",
     "errorRequired": "Este campo é obrigatorio",
@@ -155,12 +156,12 @@
     "pendingTitle": "Solicitude en revisión",
     "pendingDesc": "Estamos revisando a túa solicitude. Avisarémoste cando estea aprobada.",
     "verifiedTitle": "A túa tenda está activa!",
-    "verifiedDesc": "Xa podes xestionar os teus produtos e pedidos desde o teu panel de vendedor.",
+    "verifiedDesc": "Xa podes xestionar os teus produtos e pedidos dende o teu panel de vendedor.",
     "rejectedTitle": "Solicitude rexeitada",
     "rejectedDesc": "A túa solicitude non foi aprobada. Contacta co soporte para máis información.",
     "editTitle": "Corrixir solicitude",
     "editSubtitle": "Corrixe os datos indicados e volve enviar a túa solicitude.",
-    "resubmitNotice": "A túa solicitude corrixida volverá a estado pendente para a súa revisión.",
+    "resubmitNotice": "A túa solicitude corrixida voltará a estado pendente para a súa revisión.",
     "resubmit": "Reenviar solicitude",
     "rejectionReason": "Motivo do rexeitamento",
     "cancelApplicationDesc": "Se non desexas corrixir a solicitude, podes cancelala e comezar de novo.",
@@ -182,6 +183,8 @@
     "subtotal": "Subtotal",
     "tax": "IVE incluído (21%)",
     "shipping": "Envío",
+    "freeShipping": "Gratis",
+    "discount": "Desconto",
     "total": "Total",
     "goToPayment": "Ir ao pagamento",
     "continueToPayment": "Continuar ao pagamento",
@@ -190,6 +193,16 @@
     "newAddress": "Novo enderezo",
     "save": "Gardar",
     "saving": "Gardando...",
+    "selectAddress": "Selecciona enderezo de envío e facturación",
+    "shippingAddress": "Enderezo de envío",
+    "billingAddress": "Enderezo de facturación",
+    "sameAsBilling": "Usar o mesmo enderezo para facturación",
+    "enterPayment": "Introduce o teu método de pagamento",
+    "couponQuestion": "Tes un código de desconto?",
+    "couponPlaceholder": "Introduce o teu código",
+    "couponApply": "Aplicar",
+    "couponApplied": "Cupón aplicado",
+    "couponInvalid": "Código inválido ou caducado",
     "addr": {
       "fullName": "Nome completo",
       "address": "Enderezo",
@@ -198,17 +211,76 @@
       "province": "Provincia (opcional)",
       "postalCode": "Código postal",
       "country": "País"
-    },
-    "selectAddress": "Selecciona enderezo de envío e facturación",
-    "shippingAddress": "Enderezo de envío",
-    "billingAddress": "Enderezo de facturación",
-    "sameAsBilling": "Usar o mesmo enderezo para facturación",
-    "enterPayment": "Introduce o teu método de pagamento"
+    }
   },
   "cart": {
     "title": "Cesta",
     "empty": "A túa cesta está baleira",
     "remove": "Eliminar"
+  },
+  "orders": {
+    "title": "Historial de pedidos",
+    "empty": "Aínda non tes pedidos",
+    "order": "Pedido",
+    "date": "Data",
+    "status": "Estado",
+    "units": "Unidades",
+    "shippingCost": "Gastos de envío",
+    "shippingAddress": "Enderezo de envío",
+    "billingAddress": "Enderezo de facturación"
+  },
+  "favorites": {
+    "title": "Os teus favoritos",
+    "empty": "Aínda non tes favoritos"
+  },
+  "profile": {
+    "myAccount": "A miña Conta",
+    "tabs": {
+      "dashboard": "Panel de control",
+      "info": "Información",
+      "addresses": "Enderezos",
+      "security": "Seguridade"
+    },
+    "manage": "Xestionar",
+    "userPanel": "Panel de Usuario",
+    "info": {
+      "currentInfo": "Información Actual",
+      "editInfo": "Editar Información",
+      "nameRequired": "O nome é obrigatorio",
+      "lastNameRequired": "O apelido é obrigatorio",
+      "imageFormat": "Formato non permitido. Usa JPG, PNG ou WEBP.",
+      "imageSize": "A imaxe non pode superar os 2MB.",
+      "imageUploadError": "Erro ao subir a imaxe",
+      "imageUpdated": "Imaxe actualizada correctamente",
+      "connectionError": "Erro de conexión",
+      "uploading": "Subindo...",
+      "changeImage": "Cambiar Imaxe",
+      "saving": "Gardando...",
+      "saveChanges": "Gardar Cambios",
+      "confirmChanges": "Estás seguro de gardar os cambios?",
+      "confirm": "Confirmar",
+      "close": "Pechar",
+      "profileUpdated": "Perfil actualizado correctamente"
+    },
+    "addresses": {
+      "title": "Os meus Enderezos",
+      "main": "Enderezo Principal",
+      "setMain": "Usar como principal",
+      "edit": "Editar",
+      "delete": "Eliminar",
+      "empty": "Non tes enderezos gardados.",
+      "addNew": "Engadir Novo Enderezo",
+      "save": "Gardar Enderezo",
+      "saved": "Enderezo gardado correctamente",
+      "municipality": "Municipio"
+    },
+    "security": {
+      "title": "Cambiar Contrasinal",
+      "currentPassword": "Contrasinal actual",
+      "update": "Actualizar contrasinal",
+      "updated": "Contrasinal actualizado correctamente",
+      "error": "Erro ao actualizar o contrasinal"
+    }
   },
   "admin": {
     "rejectTitle": "Rexeitar solicitude",
@@ -232,7 +304,7 @@
     "detail": {
       "userData": "Datos do usuario",
       "name": "Nome",
-      "email": "Correo",
+      "email": "Correo electrónico",
       "role": "Rol",
       "account": "Conta",
       "active": "Activa",
@@ -247,7 +319,7 @@
       "city": "Cidade",
       "zip": "CP",
       "country": "País",
-      "accountId": "ID de conta",
+      "accountId": "ID da conta",
       "accountCreated": "Conta creada",
       "yes": "Si",
       "no": "Non",
@@ -271,7 +343,7 @@
   "dashboard": {
     "seller": {
       "title": "A miña Tenda",
-      "desc": "Xestiona os teus pedidos, produtos e ganancias desde aquí.",
+      "desc": "Xestiona os teus pedidos, produtos e ganancias dende aquí.",
       "tabs": {
         "overview": "Resumo",
         "orders": "Pedidos",
@@ -288,7 +360,7 @@
       "revenueByMonth": "Ingresos por mes",
       "lastMovements": "Últimos movementos",
       "order": "Pedido",
-      "noMovements": "Non hai movementos aínda."
+      "noMovements": "Aínda non hai movementos."
     },
     "orders": {
       "loading": "Cargando pedidos…",
@@ -341,6 +413,9 @@
       "confirmDelete": "Eliminar este produto?",
       "edit": "Editar",
       "delete": "Eliminar",
+      "deleted": "Produto eliminado",
+      "stockError": "Erro ao actualizar o stock",
+      "saved": "Produto gardado",
       "table": {
         "product": "Produto",
         "price": "Prezo",
@@ -352,6 +427,8 @@
         "newTitle": "Novo produto",
         "changeImage": "Cambiar imaxe",
         "uploadImage": "Subir imaxe",
+        "noImage": "Sen imaxe",
+        "imageRequired": "A imaxe é obrigatoria.",
         "formatError": "Usa JPG, PNG ou WEBP.",
         "sizeError": "Máximo 2MB.",
         "name": "Nome",
@@ -380,7 +457,7 @@
       "noStock": "sen stock",
       "attention": "ATENCIÓN",
       "recentActivity": "Actividade recente",
-      "noActivity": "Non hai actividade aínda.",
+      "noActivity": "Aínda non hai actividade.",
       "customer": "Cliente"
     },
     "settings": {
@@ -393,71 +470,11 @@
       "zip": "Código postal",
       "country": "País",
       "description": "Descrición breve",
+      "originAddress": "Enderezo de orixe",
       "saving": "Gardando…",
       "save": "Gardar cambios",
-      "success": "✅ Gardado correctamente.",
-      "error": "❌ Erro ao gardar."
-    }
-  },
-  "orders": {
-    "title": "Historial de pedidos",
-    "empty": "Aínda non tes pedidos",
-    "order": "Pedido",
-    "date": "Data",
-    "status": "Estado",
-    "units": "Unidades",
-    "shippingCost": "Gastos de envío",
-    "shippingAddress": "Enderezo de envío",
-    "billingAddress": "Enderezo de facturación"
-  },
-  "favorites": {
-    "title": "Os teus favoritos",
-    "empty": "Aínda non tes favoritos"
-  },
-  "profile": {
-    "myAccount": "A miña Conta",
-    "tabs": {
-      "dashboard": "Panel de control",
-      "info": "Información",
-      "addresses": "Enderezos",
-      "security": "Seguridade"
-    },
-    "manage": "Xestionar",
-    "userPanel": "Panel de Usuario",
-    "info": {
-      "currentInfo": "Información Actual",
-      "editInfo": "Editar Información",
-      "nameRequired": "O nome é obrigatorio",
-      "lastNameRequired": "O apelido é obrigatorio",
-      "imageFormat": "Formato non permitido. Usa JPG, PNG ou WEBP.",
-      "imageSize": "A imaxe non pode superar os 2MB.",
-      "imageUploadError": "Erro ao subir a imaxe",
-      "imageUpdated": "Imaxe actualizada correctamente",
-      "connectionError": "Erro de conexión",
-      "uploading": "Subindo...",
-      "changeImage": "Cambiar Imaxe",
-      "saving": "Gardando...",
-      "saveChanges": "Gardar Cambios",
-      "confirmChanges": "Estás seguro de que queres gardar os cambios?",
-      "confirm": "Confirmar",
-      "close": "Pechar",
-      "profileUpdated": "Perfil actualizado correctamente"
-    },
-    "addresses": {
-      "title": "Os meus Enderezos",
-      "main": "Enderezo Principal",
-      "setMain": "Usar como principal",
-      "delete": "Eliminar",
-      "addNew": "Engadir Novo Enderezo",
-      "save": "Gardar Enderezo",
-      "saved": "Enderezo gardado correctamente",
-      "municipality": "Municipio"
-    },
-    "security": {
-      "title": "Cambiar Contrasinal",
-      "currentPassword": "Contrasinal actual",
-      "update": "Actualizar contrasinal",
-      "updated": "Contrasinal actualizado"
+      "success": "Gardado correctamente.",
+      "error": "Erro ao gardar."
     }
   },
   "review": {


### PR DESCRIPTION
## Descripción
Añade las traducciones que faltaban al archivo `es.json` y genera los archivos completos para inglés (`en.json`), catalán (`ca.json`) y gallego (`gl.json`).

---
## Historia de Usuario
US #

## Tareas
- Closes #

---
## Tipo de cambio
- [ ] Feature
- [x] Bug
- [ ] UI / Estilos

---
## Cambios realizados
- Añadidas 18 claves nuevas a `es.json` (`product.noStock`, `checkout.freeShipping`, cupones, dashboard products, etc.)
- También a  `en.json` con traducción completa al inglés
- También a `ca.json` con traducción completa al catalán
- También a `gl.json` con traducción completa al gallego

---
## Checklist
- [x] Funciona como se espera
- [x] Cumple criterios de aceptación de la tarea
- [x] No rompe otras partes
- [x] Probado manualmente
- [x] Estoy trabajando en una rama específica para esta tarea