### PR TITLE
feat(product): soft delete para preservar historial de pedidos

### DIFF
--- a/migrations/versions/19f95b1b1cfc_.py
+++ b/migrations/versions/19f95b1b1cfc_.py
@@ -1,8 +1,8 @@
 """empty message
 
-Revision ID: 0678f0ff9912
+Revision ID: 19f95b1b1cfc
 Revises: 
-Create Date: 2026-03-18 07:34:20.772203
+Create Date: 2026-03-18 19:33:49.869260
 
 """
 from alembic import op
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision = '0678f0ff9912'
+revision = '19f95b1b1cfc'
 down_revision = None
 branch_labels = None
 depends_on = None
@@ -158,14 +158,16 @@ def upgrade():
     sa.Column('price', sa.Float(), nullable=False),
     sa.Column('image_url', sa.Text(), nullable=True),
     sa.Column('other_image_url', sa.JSON(), nullable=True),
-    sa.Column('height', sa.Float(), nullable=True),
-    sa.Column('width', sa.Float(), nullable=True),
-    sa.Column('length', sa.Float(), nullable=True),
-    sa.Column('weight', sa.Float(), nullable=True),
+    sa.Column('height', sa.Float(), nullable=False),
+    sa.Column('width', sa.Float(), nullable=False),
+    sa.Column('length', sa.Float(), nullable=False),
+    sa.Column('weight', sa.Float(), nullable=False),
     sa.Column('stock', sa.Integer(), nullable=False),
     sa.Column('discount', sa.Float(), nullable=False),
     sa.Column('condition', sa.Enum('new', 'used', 'refurbished', 'broken', name='productcondition'), nullable=False),
     sa.Column('created_at', sa.DateTime(), nullable=True),
+    sa.Column('is_deleted', sa.Boolean(), nullable=False),
+    sa.Column('deleted_at', sa.DateTime(), nullable=True),
     sa.Column('item_id', sa.Integer(), nullable=False),
     sa.Column('seller_id', sa.Integer(), nullable=False),
     sa.ForeignKeyConstraint(['item_id'], ['item.id'], ),

--- a/src/api/controllers/products_controller.py
+++ b/src/api/controllers/products_controller.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import joinedload
 from deep_translator import GoogleTranslator
 import cloudinary.uploader
 from api.models.seller import Seller
+from datetime import datetime, timezone
 
 product_bp = Blueprint('product', __name__, url_prefix='/product')
 
@@ -25,7 +26,7 @@ def translate_text(text, target_lang):
 @product_bp.route('', methods=['GET'])
 def get_products():
     locale = request.args.get("locale", "es")
-    products = Product.query.all()
+    products = Product.query.filter_by(is_deleted=False).all()
     return jsonify([p.to_dict(locale=locale) for p in products]), 200
 
 
@@ -47,7 +48,7 @@ def search_products():
     conditions = [c.strip() for c in conditions_param.split(",")
                   if c.strip()] if conditions_param else []
 
-    products = Product.query.options(
+    products = Product.query.filter_by(is_deleted=False).options(
         joinedload(Product.item)
         .joinedload(Item.subcategory)
         .joinedload(Subcategory.category)
@@ -128,7 +129,7 @@ def search_products():
 def get_product(id):
     locale = request.args.get("locale", "es")
     product = Product.query.get(id)
-    if product is None:
+    if product is None or product.is_deleted:
         abort(404, description=f"Producto con id {id} no encontrado")
     return jsonify(product.to_dict(locale=locale)), 200
 
@@ -231,7 +232,7 @@ def create_product():
 @jwt_required()
 def update_product(id):
     product = Product.query.get(id)
-    if product is None:
+    if product is None or product.is_deleted:
         abort(404, description=f"Producto con id {id} no encontrado")
 
     if request.content_type and "multipart/form-data" in request.content_type:
@@ -317,6 +318,7 @@ def get_top_sales():
         Product,
         func.sum(OrderDetail.quantity).label("total_sold")
     ).join(Product.order_details)\
+    .filter(Product.is_deleted == False)\
     .group_by(Product.id)\
     .order_by(text("total_sold DESC"))\
     .limit(10)\
@@ -330,13 +332,22 @@ def get_top_sales():
 
 
 @product_bp.route('/<int:id>', methods=['DELETE'])
+@jwt_required()
 def delete_product(id):
+    user_id = get_jwt_identity()
+    seller = Seller.query.filter_by(user_id=user_id).first()
+    if not seller:
+        abort(403, description="No tienes perfil de vendedor")
+
     product = Product.query.get(id)
-    if product is None:
+    if product is None or product.is_deleted:
         abort(404, description=f"Producto con id {id} no encontrado")
+    if product.seller_id != seller.id:
+        abort(403, description="No tienes permiso para eliminar este producto")
 
     try:
-        db.session.delete(product)
+        product.is_deleted = True
+        product.deleted_at = datetime.now(timezone.utc)
         db.session.commit()
     except Exception:
         db.session.rollback()

--- a/src/api/models/product.py
+++ b/src/api/models/product.py
@@ -1,4 +1,4 @@
-from sqlalchemy import String, DateTime, Float, Integer, ForeignKey, Text, JSON, Enum
+from sqlalchemy import String, DateTime, Float, Integer, ForeignKey, Text, JSON, Enum, Boolean
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from datetime import datetime
 from api.models import db
@@ -24,16 +24,16 @@ class Product(db.Model):
     price: Mapped[float] = mapped_column(Float(), nullable=False, default=0.0)
     image_url: Mapped[str] = mapped_column(Text(), nullable=True)
     other_image_url: Mapped[dict] = mapped_column(JSON, nullable=True)
-    height: Mapped[float] = mapped_column(Float(), nullable=True)   # cm
-    width: Mapped[float] = mapped_column(Float(), nullable=True)    # cm
-    length: Mapped[float] = mapped_column(Float(), nullable=True)   # cm
-    weight: Mapped[float] = mapped_column(Float(), nullable=True)   # kg
+    height: Mapped[float] = mapped_column(Float(), nullable=False, default=10.0)  # cm
+    width: Mapped[float] = mapped_column(Float(), nullable=False, default=10.0)   # cm
+    length: Mapped[float] = mapped_column(Float(), nullable=False, default=10.0)  # cm
+    weight: Mapped[float] = mapped_column(Float(), nullable=False, default=0.5)   # kg
     stock: Mapped[int] = mapped_column(Integer(), nullable=False, default=0)
     discount: Mapped[float] = mapped_column(Float(), nullable=False, default=0)
-    condition: Mapped[ProductCondition] = mapped_column(
-        Enum(ProductCondition), nullable=False, default=ProductCondition.new
-    )
+    condition: Mapped[ProductCondition] = mapped_column( Enum(ProductCondition), nullable=False, default=ProductCondition.new )
     created_at: Mapped[datetime] = mapped_column(DateTime(), nullable=True)
+    is_deleted: Mapped[bool] = mapped_column(Boolean(), nullable=False, default=False)
+    deleted_at: Mapped[datetime] = mapped_column(DateTime(), nullable=True, default=None)
 
     # ── ForeignKey ─────────────────────────────────────────────────────────────
     item_id: Mapped[int] = mapped_column(ForeignKey("item.id"), nullable=False)


### PR DESCRIPTION
PR - Soft delete en productos

## Descripción
Los productos borrados desaparecían de la base de datos, lo que rompía
el historial de pedidos al perder la referencia en OrderDetail. Se
implementa soft delete para que el borrado sea lógico: el producto deja
de aparecer en el catálogo pero la fila se conserva en BD.

---

## Historia de Usuario
- #

## Tareas
- #

---

## Tipo de cambio
- [x] Feature

---

## Cambios realizados
- `models/product.py` — añadidas columnas `is_deleted` (Boolean, default False) y `deleted_at` (DateTime, nullable)
- `models/product.py` — `height`, `width`, `length` y `weight` pasan a `nullable=False` con defaults (10.0 cm / 0.5 kg)
- `routes/product.py` — `DELETE` pasa a soft delete: asigna `is_deleted=True` y `deleted_at`, sin borrar la fila
- `routes/product.py` — `DELETE` añade `@jwt_required()` y comprueba que el vendedor sea el propietario del producto
- `routes/product.py` — `GET`, `GET /<id>`, `PUT /<id>` y `search` filtran productos con `is_deleted=False`
- `routes/product.py` — `top-sales` filtra productos con `is_deleted=False`
- Migración: `flask db migrate -m "soft delete en producto"` + `flask db migrate -m "dimensiones y peso obligatorios con default"` + `flask db upgrade`

---

## Checklist
- [ ] Funciona como se espera
- [ ] Cumple criterios de aceptación de la tarea
- [ ] No rompe otras partes
- [ ] Probado manualmente
- [ ] Estoy trabajando en una rama específica para esta tarea